### PR TITLE
fix: fix exports of types form module

### DIFF
--- a/src/__test__/index.js
+++ b/src/__test__/index.js
@@ -5,6 +5,15 @@ describe("utils", () => {
     it("should export property types", () => {
         expect(utils).to.have.property("types");
     });
+    it("should export isString", () => {
+        expect(utils).to.respondTo("isString");
+    });
+    it("should export isGiven", () => {
+        expect(utils).to.respondTo("isGiven");
+    });
+    it("should export isEmail", () => {
+        expect(utils).to.respondTo("isEmail");
+    });
     it("should export slugify", () => {
         expect(utils).to.respondTo("slugify");
     });

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,7 @@
+export {
+    isGiven,
+    isEmail,
+    isString
+} from "./types";
 export * as types from "./types";
 export slugify from "./slugify";

--- a/src/types/__test__/index.js
+++ b/src/types/__test__/index.js
@@ -5,4 +5,10 @@ describe("types", () => {
     it("should export isEmail", () => {
         expect(types).to.respondTo("isEmail");
     });
+    it("should export isGiven", () => {
+        expect(types).to.respondTo("isGiven");
+    });
+    it("should export isString", () => {
+        expect(types).to.respondTo("isString");
+    });
 });

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,1 +1,3 @@
 export isEmail from "./isEmail";
+export isGiven from "./isGiven";
+export isString from "./isString";


### PR DESCRIPTION
This PR fixe the export of the functions from the module.

Now types functions can be imported in the following ways:

``` javascript
import { types } from "konnektid-js-utils";

import { isString, ... } from "konnektid-js-utils";

import isString form "konnektid-js-utils/dist/types/isString";
```
